### PR TITLE
feat(wrappers): included django-stomp instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ For Django, add `"autodynatrace.wrappers.django"` to `INSTALLED_APPS`
 
 * `AUTODYNATRACE_CAPTURE_HEADERS`: Default: `False`, set to `True` to capture request headers
 * `AUTODYNATRACE_LOG_LEVEL`: Default `WARNING`
+* `AUTODYNATRACE_AUTOMATIC_LOG_CORRELATION`: Default `False`, set to `True` to enrich logs with trace_id and span_id
 * `AUTODYNATRACE_FORKABLE`: Default `False`, set to `True` to [instrument forked processes](https://github.com/Dynatrace/OneAgent-SDK-for-Python#using-the-oneagent-sdk-for-python-with-forked-child-processes-only-available-on-linux). Use this for gunicorn/uwsgi
 * `AUTODYNATRACE_VIRTUAL_HOST`: Overwrite the default Virtual Host for web frameworks
 * `AUTODYNATRACE_APPLICATION_ID`: Overwrite the default Application Name for web frameworks

--- a/autodynatrace/__init__.py
+++ b/autodynatrace/__init__.py
@@ -54,6 +54,7 @@ INSTRUMENT_LIBS = {
     "starlette": True,
     "aiohttp": True,
     "bottle": True,
+    "django_stomp": True,
 }
 
 

--- a/autodynatrace/wrappers/dbapi/__init__.py
+++ b/autodynatrace/wrappers/dbapi/__init__.py
@@ -8,7 +8,7 @@ from ..utils import normalize_vendor
 class TracedCursor(wrapt.ObjectProxy):
     def __init__(self, cursor, db_info):
         super(TracedCursor, self).__init__(cursor)
-        self.db_info = f"{db_info}"
+        self.db_info = db_info
         self._self_last_execute_operation = None
         self._original_cursor = cursor
 

--- a/autodynatrace/wrappers/django/log.py
+++ b/autodynatrace/wrappers/django/log.py
@@ -1,0 +1,22 @@
+import os
+import logging
+from ...sdk import sdk
+
+auto_log_correlation = os.environ.get("AUTODYNATRACE_AUTOMATIC_LOG_CORRELATION", "False").strip().lower() in (
+"true", "1")
+
+def instrument_log():
+    old_factory = logging.getLogRecordFactory()
+
+    def record_factory(*args, **kwargs):
+        record = old_factory(*args, **kwargs)
+        if sdk:
+            trace_info = sdk.tracecontext_get_current()
+            span_id, trace_id = trace_info.span_id, trace_info.trace_id
+            record.span_id = span_id
+            record.trace_id = trace_id
+
+        return record
+
+    if auto_log_correlation:
+        logging.setLogRecordFactory(record_factory)

--- a/autodynatrace/wrappers/django/wrapper.py
+++ b/autodynatrace/wrappers/django/wrapper.py
@@ -6,19 +6,20 @@ from ...sdk import sdk
 
 from .middlewares import insert_dynatrace_middleware
 from .db import instrument_db
+from .log import instrument_log
 
 
 def instrument():
     @wrapt.patch_function_wrapper("django", "setup")
     def dynatrace_setup(wrapped, instance, args, kwargs):
         from django.conf import settings
-
-        if "autodynatrace.wrappers.django" not in settings.INSTALLED_APPS:
+        autodynatrace_wrapper_django = "autodynatrace.wrappers.django"
+        if autodynatrace_wrapper_django not in settings.INSTALLED_APPS:
             if isinstance(settings.INSTALLED_APPS, tuple):
 
-                settings.INSTALLED_APPS = settings.INSTALLED_APPS + ("autodynatrace.wrappers.django",)
+                settings.INSTALLED_APPS = settings.INSTALLED_APPS + (autodynatrace_wrapper_django,)
             else:
-                settings.INSTALLED_APPS.append("autodynatrace.wrappers.django")
+                settings.INSTALLED_APPS.append(autodynatrace_wrapper_django)
 
             logger.debug("Added autodynatrace to settings.INSTALLED_APPS")
         wrapped(*args, **kwargs)
@@ -27,3 +28,4 @@ def instrument():
 def instrument_django():
     insert_dynatrace_middleware()
     instrument_db()
+    instrument_log()

--- a/autodynatrace/wrappers/django_stomp/__init__.py
+++ b/autodynatrace/wrappers/django_stomp/__init__.py
@@ -1,0 +1,1 @@
+from .wrapper import instrument

--- a/autodynatrace/wrappers/django_stomp/consumer.py
+++ b/autodynatrace/wrappers/django_stomp/consumer.py
@@ -1,0 +1,46 @@
+import oneagent
+from django.conf import settings
+from django.utils.module_loading import import_string
+from django_stomp import execution
+from ...log import logger
+from ...sdk import sdk
+from .utils import get_messaging_type_by_queue_name
+
+def instrument_consumer():
+    def wrapped_import_string(dotted_path):
+        callback_function = import_string(dotted_path)
+
+        def instrumented_callback(payload):
+            try:
+                headers = payload.headers
+                host, port = settings.STOMP_SERVER_HOST, settings.STOMP_SERVER_PORT
+                destination = headers.get("tshoot-destination")
+            except Exception as e:
+                logger.warn("autodynatrace - Could not trace Consumer(import_string): {}".format(e))
+                return callback_function(payload)
+
+            tag = None
+            if headers is not None:
+                tag = headers.get(oneagent.common.DYNATRACE_MESSAGE_PROPERTY_NAME, None)
+
+            messaging_system = sdk.create_messaging_system_info(
+                oneagent.common.MessagingVendor.RABBIT_MQ,
+                destination,
+                get_messaging_type_by_queue_name(destination),
+                oneagent.sdk.Channel(oneagent.sdk.ChannelType.TCP_IP, "{}:{}".format(host, port)),
+            )
+
+            with messaging_system:
+                with sdk.trace_incoming_message_receive(messaging_system):
+                    with sdk.trace_incoming_message_process(messaging_system, str_tag=tag) as process_message:
+                        process_message.set_correlation_id(headers.get("correlation-id"))
+                        process_message.set_vendor_message_id(headers.get("message-id"))
+                        logger.debug(
+                            f"autodynatrace - Tracing Incoming RabbitMQ host={host}, port={port},"
+                            f" routing_key={destination}, tag={tag}, headers={headers}"
+                        )
+                        return callback_function(payload)
+
+        return instrumented_callback
+
+    setattr(execution, "import_string", wrapped_import_string)

--- a/autodynatrace/wrappers/django_stomp/publisher.py
+++ b/autodynatrace/wrappers/django_stomp/publisher.py
@@ -1,0 +1,38 @@
+import oneagent
+import wrapt
+from django.conf import settings
+from django_stomp.services.producer import Publisher
+from ...log import logger
+from ...sdk import sdk
+from .utils import get_messaging_type_by_queue_name
+
+def instrument_publisher():
+    def on_send_message(wrapped, instance, args, kwargs):
+        try:
+            host, port = settings.STOMP_SERVER_HOST, settings.STOMP_SERVER_PORT
+            destination = kwargs.get("queue")
+            headers = kwargs.get("headers", {})
+
+        except Exception as e:
+            logger.warn("autodynatrace - Could not trace Publisher.send: {}".format(e))
+            return wrapped(*args, **kwargs)
+
+        messaging_system = sdk.create_messaging_system_info(
+            oneagent.common.MessagingVendor.RABBIT_MQ,
+            destination,
+            get_messaging_type_by_queue_name(destination),
+            oneagent.sdk.Channel(oneagent.sdk.ChannelType.TCP_IP, "{}:{}".format(host, port)),
+        )
+
+        with messaging_system:
+            with sdk.trace_outgoing_message(messaging_system) as outgoing_message:
+                outgoing_message.set_correlation_id(headers.get("correlation-id"))
+                tag = outgoing_message.outgoing_dynatrace_string_tag.decode("utf-8")
+                headers[oneagent.common.DYNATRACE_MESSAGE_PROPERTY_NAME] = tag
+                logger.debug(
+                    f"autodynatrace - Tracing Outgoing RabbitMQ host={host}, port={port}, routing_key={destination}, "
+                    f"tag={tag}, headers={headers}"
+                )
+                return wrapped(*args, **kwargs)
+
+    wrapt.wrap_function_wrapper(Publisher, "send", on_send_message)

--- a/autodynatrace/wrappers/django_stomp/utils.py
+++ b/autodynatrace/wrappers/django_stomp/utils.py
@@ -1,0 +1,12 @@
+import oneagent
+
+
+def get_messaging_type_by_queue_name(queue_name: str) -> int:
+    """Helper function to get queue type by name. If 'VirtualTopic' exists in the destination name
+    this queue is a TOPIC type.
+    By default the type of queue is QUEUE.
+    """
+    if "VirtualTopic" in queue_name:
+        return oneagent.common.MessagingDestinationType.TOPIC
+
+    return oneagent.common.MessagingDestinationType.QUEUE

--- a/autodynatrace/wrappers/django_stomp/wrapper.py
+++ b/autodynatrace/wrappers/django_stomp/wrapper.py
@@ -1,0 +1,6 @@
+from .consumer import instrument_consumer
+from .publisher import instrument_publisher
+
+def instrument():
+    instrument_publisher()
+    instrument_consumer()

--- a/autodynatrace/wrappers/psycopg2/wrapper.py
+++ b/autodynatrace/wrappers/psycopg2/wrapper.py
@@ -11,7 +11,7 @@ def instrument():
     def parse_dsn(dsn):
         return {c.split("=")[0]: c.split("=")[1] for c in dsn.split() if "=" in c}
 
-    class DynatraceCursor(psycopg2.extra.DictCursorBase):
+    class DynatraceCursor(psycopg2.extensions.cursor):
         def __init__(self, *args, **kwargs):
             self._dynatrace_db_info = kwargs.pop("dynatrace_db_info", None)
             super(DynatraceCursor, self).__init__(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from setuptools import setup, find_packages
 
 setup(
-    name="autodynatrace",
-    version="2.0.0",
+    name="jsm-autodynatrace",
+    version="1.0.0",
     packages=find_packages(),
     package_data={"autodynatrace": ["wrappers/*"]},
     install_requires=["wrapt>=1.11.2", "oneagent-sdk>=1.3.0", "six>=1.10.0", "autowrapt>=1.0"],


### PR DESCRIPTION
Included django-stomp instrumentation.

consumer_instrumentation
<img width="1440" alt="Screenshot 2023-07-17 at 18 44 49" src="https://github.com/juntossomosmais/OneAgent-SDK-Python-AutoInstrumentation/assets/22987079/d8703d32-0634-4268-bc53-d19f16015c87">

log with trace_id and span_id
<img width="1440" alt="Screenshot 2023-07-17 at 18 45 01" src="https://github.com/juntossomosmais/OneAgent-SDK-Python-AutoInstrumentation/assets/22987079/4ea57f7a-3efe-455e-b722-a16f5834c97f">
