### PR TITLE
fix(django-stomp): included check for None destination

### DIFF
--- a/autodynatrace/wrappers/django_stomp/utils.py
+++ b/autodynatrace/wrappers/django_stomp/utils.py
@@ -1,12 +1,14 @@
+from typing import Optional
+
 import oneagent
 
 
-def get_messaging_type_by_queue_name(queue_name: str) -> int:
+def get_messaging_type_by_queue_name(queue_name: Optional[str] = None) -> int:
     """Helper function to get queue type by name. If 'VirtualTopic' exists in the destination name
     this queue is a TOPIC type.
     By default the type of queue is QUEUE.
     """
-    if "VirtualTopic" in queue_name:
+    if queue_name and "VirtualTopic" in queue_name:
         return oneagent.common.MessagingDestinationType.TOPIC
 
     return oneagent.common.MessagingDestinationType.QUEUE

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="jsm-autodynatrace",
-    version="1.0.0",
+    version="1.0.1",
     packages=find_packages(),
     package_data={"autodynatrace": ["wrappers/*"]},
     install_requires=["wrapt>=1.11.2", "oneagent-sdk>=1.3.0", "six>=1.10.0", "autowrapt>=1.0"],


### PR DESCRIPTION
## Info

Included check to validate if the queue is not None then check if `VirtualTopic` exists in destionation_name.